### PR TITLE
Add Control-w shortcut to close application windows

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -35,6 +35,7 @@
 #include "status.h"
 #include "style.h"
 #include "vpn.h"
+#include "util.h"
 
 GtkWidget *list, *notebook, *main_window;
 GHashTable *technology_types, *services;
@@ -612,6 +613,7 @@ static void startup(GtkApplication *app, gpointer user_data)
 
 	create_content();
 
+	g_signal_connect(G_OBJECT(main_window), "key_press_event", G_CALLBACK(handle_keyboard_shortcut), NULL);
 	gtk_widget_show_all(main_window);
 
 #ifdef USE_STATUS_ICON

--- a/src/settings.c
+++ b/src/settings.c
@@ -710,6 +710,7 @@ static void init_settings(struct settings *sett)
 	                 G_CALLBACK(list_item_selected), sett->notebook);
 	g_signal_connect(sett->apply, "clicked",
 	                 G_CALLBACK(apply_cb), sett);
+	g_signal_connect(sett->window, "key_press_event", G_CALLBACK(handle_keyboard_shortcut), sett);
 
 	style_set_margin(GTK_WIDGET(grid), MARGIN_LARGE);
 	gtk_widget_set_margin_top(sett->apply, MARGIN_LARGE);

--- a/src/util.c
+++ b/src/util.c
@@ -23,6 +23,7 @@
 #include <glib/gi18n.h>
 #include <gtk/gtk.h>
 #include <string.h>
+#include <gdk/gdkkeysyms.h>
 
 #include "config.h"
 #include "main.h"
@@ -316,4 +317,17 @@ GVariant *dual_hash_table_to_variant(DualHashTable *dtable)
 	GVariant *out = g_variant_dict_end(dict);
 	g_variant_dict_unref(dict);
 	return out;
+}
+
+gboolean handle_keyboard_shortcut(GtkWidget *widget, GdkEventKey *event, gpointer data) {
+	int isCtrl = event->state & GDK_CONTROL_MASK;
+
+	switch (event->keyval) {
+		case GDK_KEY_w:
+			if (isCtrl)
+				gtk_widget_destroy(widget);
+			break;
+	}
+
+	return FALSE;
 }

--- a/src/util.h
+++ b/src/util.h
@@ -52,4 +52,6 @@ void dual_hash_table_foreach(DualHashTable *table, DualHashTableIter cb,
                              gpointer user_data);
 GVariant *dual_hash_table_to_variant(DualHashTable *table);
 
+gboolean handle_keyboard_shortcut(GtkWidget *widget, GdkEventKey *event, gpointer data);
+
 #endif /* _CONNMAN_GTK_UTIL_H */


### PR DESCRIPTION
This allows the application window to be closed when used in a tiling window manager, where the window's titlebar is not shown.

Ref issue #31 