### PR TITLE
Fix prefered/preferred typo in source and translations

### DIFF
--- a/po/connman-gtk.pot
+++ b/po/connman-gtk.pot
@@ -271,7 +271,7 @@ msgid "Enabled"
 msgstr ""
 
 #: src/settings.c:293
-msgid "Prefered"
+msgid "Preferred"
 msgstr ""
 
 #: src/settings.c:303

--- a/po/es.po
+++ b/po/es.po
@@ -271,7 +271,7 @@ msgid "Enabled"
 msgstr "Activar"
 
 #: src/settings.c:293
-msgid "Prefered"
+msgid "Preferred"
 msgstr "Preferido"
 
 #: src/settings.c:303

--- a/po/fi.po
+++ b/po/fi.po
@@ -272,7 +272,7 @@ msgid "Enabled"
 msgstr "Päällä"
 
 #: src/settings.c:293
-msgid "Prefered"
+msgid "Preferred"
 msgstr "Ensisijainen"
 
 #: src/settings.c:303

--- a/po/pt.po
+++ b/po/pt.po
@@ -271,7 +271,7 @@ msgid "Enabled"
 msgstr "Ativado"
 
 #: src/settings.c:293
-msgid "Prefered"
+msgid "Preferred"
 msgstr "Preferido"
 
 #: src/settings.c:303

--- a/po/ru.po
+++ b/po/ru.po
@@ -272,7 +272,7 @@ msgid "Enabled"
 msgstr "Включено"
 
 #: src/settings.c:293
-msgid "Prefered"
+msgid "Preferred"
 msgstr "По умолчанию"
 
 #: src/settings.c:303

--- a/src/settings.c
+++ b/src/settings.c
@@ -290,8 +290,8 @@ static void add_ipv_page(struct settings *sett, int ipv)
 		                      _("Disabled"), TRUE);
 		add_page_to_combo_box(sett, ipv6_privacy, "enabled",
 		                      _("Enabled"), !strcmp("enabled", cur));
-		add_page_to_combo_box(sett, ipv6_privacy, "prefered",
-		                      _("Prefered"), !strcmp("prefered", cur));
+		add_page_to_combo_box(sett, ipv6_privacy, "preferred",
+		                      _("Preferred"), !strcmp("preferred", cur));
 		g_free(cur);
 	}
 }


### PR DESCRIPTION
Detected by Debian's lintian tool whilst packaging connman-gtk