### PR TITLE
Update manpage section

### DIFF
--- a/data/connman-gtk.1
+++ b/data/connman-gtk.1
@@ -2,7 +2,7 @@
 .\"
 .\" Copyright (C) 2015 Intel Corporation
 .\"
-.TH CONNMAN-GTK "8" "2015-11-05"
+.TH CONNMAN-GTK "1" "2015-11-05"
 .SH NAME
 ConnMan-GTK \- GTK GUI for ConnMan
 .SH SYNOPSIS


### PR DESCRIPTION
Based on the current manpage's extension, and additionally as a user-executable program, the connman-gtk manpage should really be in section 1.

Detected by Debian's lintian tool whilst packaging connman-gtk